### PR TITLE
Fix bad autoload configuration

### DIFF
--- a/lib/ezcomponents/autoload/console_autoload.php
+++ b/lib/ezcomponents/autoload/console_autoload.php
@@ -71,6 +71,6 @@ return array(
     'ezcConsoleTableOptions'                        => 'ConsoleTools/options/table.php',
     'ezcConsoleTableRow'                            => 'ConsoleTools/table/row.php',
     'ezcConsoleInputHelpGenerator'                  => 'ConsoleTools/interfaces/input_help_generator.php',
-    'ezcConsoleStandardInputHelpGenerator'          => 'ConsoleTools/input/help_generators/standard.php',
+    'ezcConsoleInputStandardHelpGenerator'          => 'ConsoleTools/input/help_generators/standard.php',
 );
 ?>


### PR DESCRIPTION
Autoload was declared for
ezcConsoleStandardInputHelpGenerator
but the class is
ezcConsoleInputStandardHelpGenerator